### PR TITLE
Use baseUrl for favicon paths in html.mustache

### DIFF
--- a/templates/default/views/html.mustache
+++ b/templates/default/views/html.mustache
@@ -26,8 +26,8 @@
     {{#page.image}}<meta name="twitter:image" content="{{.}}">{{/page.image}}
     
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon.svg">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon.svg">
+    <link rel="icon" type="image/png" sizes="32x32" href="{{baseUrl}}/favicon.svg">
+    <link rel="icon" type="image/png" sizes="16x16" href="{{baseUrl}}/favicon.svg">
     <link rel="manifest" href="/site.webmanifest">
 
     <link rel="stylesheet" href="{{baseUrl}}/css/modern-normalize.css">


### PR DESCRIPTION
Updated favicon link tags to use the {{baseUrl}} variable, ensuring correct favicon paths when the site is not served from the root.